### PR TITLE
initial version of a README file

### DIFF
--- a/README.org
+++ b/README.org
@@ -1,0 +1,89 @@
+#+TITLE: org-linker-edna
+
+Create [[https://www.nongnu.org/org-edna-el/][org-edna]] dependencies (=:TRIGGER:= and =:BLOCKER:= properties)
+
+* Basic example
+
+Here is an example on the basic functionality of =org-linker-edna=.
+
+Consider these two Org mode headings:
+
+: ** STARTED Cleaning my desk
+: 
+: ** Make my desk messy again
+
+They do have a natural dependency: /it is required to have a clean
+desk in order to be able to mess it up again/.
+
+Therefore, you can define a dependency such as cleaning up the desk is
+required to be set to =DONE= before being messy can be set to =DONE=. 
+
+With =org-edna=, you do have two possibilities that may be applied in
+this example: =TRIGGER= and =BLOCKER= properties. This would require
+manual effort from you to create the corresponding properties within
+the drawers. And this is what =org-linker-edna= is able to do for you
+on your fingertips.
+
+By invoking =M-x org-linker-edna= (or binding it to a keyboard
+shortcut), you can get the following result:
+
+: ** STARTED Cleaning my desk
+: :PROPERTIES:
+: :ID:       ac3da9ff-1069-40ee-8aba-74734a64b820
+: :TRIGGER:  ids(0f99de80-8592-4a5e-8cf8-5d27f23c1d8c) todo!(TODO) scheduled!("++1d")
+: :END:
+: 
+: ** Make my desk messy again
+: :PROPERTIES:
+: :ID:       0f99de80-8592-4a5e-8cf8-5d27f23c1d8c
+: :BLOCKER:  ids(ac3da9ff-1069-40ee-8aba-74734a64b820)
+: :END:
+
+As you can see, there are several things which were done for you. By
+selecting a followup-status (=TODO=) and a scheduled day (=++1d= for
+the next day), the "get messy again"-task now has its dependency
+defined:
+
+1. For referencing the headings, [[https://en.wikipedia.org/wiki/Uuid][UUIDs]] were generated for both, source
+   and destination.
+2. The cleaner task got extended by a property which sets the messy
+   task to =TODO= and schedules it for the next day as soon as the
+   clean-up task gets set to =DONE= (or =CANCELLED=).
+3. The "get back to my usual mess"-task gets a =BLOCKER= property set.
+   - While this is somehow redundant, you get a bi-directional
+     dependency with a "back-link".
+   - With [[https://github.com/toshism/org-linker-edna/issues/5][this feature request]], you will maybe get navigable Org mode
+     links.
+
+As you can see clearly, =org-linker-edna= helps you to *minimize
+manual effort for creating dependencies*.
+
+* Installation
+
+Please do install [[https://github.com/toshism/org-linker][org-linker]] beforehand because =org-super-links= is
+using its functionality.
+
+Using [[https://github.com/quelpa/quelpa][quelpa]] makes it easy to install =org-super-links=. Example basic
+configuration:
+#+begin_src elisp
+  (use-package org-super-links
+    :quelpa (org-super-links :repo "toshism/org-linker-edna" :fetcher github)
+    :bind (("C-c s e" . org-linker-edna)) ;; follows org-super-link binding patterns
+#+end_src
+
+* Notes
+
+This is still kind of in flux, so things could change... It's starting
+to settle down, but I'm still playing around with the idea a bit. If
+you want something that will stay reasonably stable pick a tag.
+
+* Related Resources
+
+- [[https://github.com/toshism/org-linker][org-linker]] which is the general foundation of =org-linker-edna=
+- [[https://github.com/toshism/org-super-links][org-super-links]] an independent package to create Org mode links to headings with auto-backlinks
+- [[https://karl-voit.at/2020/08/14/project-mgt-draft/][This blog article]] that drafts an example workflow for Org mode with advanced usage of dependencies
+- [[https://orgmode.org/worg/org-contrib/org-depend.html][org-depend]]: a much simpler alternative to =org-edna= which does not have a corresponding tool like =org-linker-edna= (at least to my knowledge)
+
+* License
+
+[[file:LICENSE][GPLv3]]


### PR DESCRIPTION
This is a draft for your README file. It would solve #2.

I tried to come up with a README file that reflects the current situation. Therefore, I omitted changelog and other things.

I added a shameless plug for my workflow blog article. Of course, feel free to remove it if you don't consider this a helpful resource for users of `org-linker-edna`.