### PR TITLE
Fix helm-build-sync-source invalid function error

### DIFF
--- a/org-linker-edna.el
+++ b/org-linker-edna.el
@@ -29,6 +29,9 @@
 
 ;;; Code:
 
+(eval-when-compile
+  (require 'helm-source nil t))
+
 (require 'org-linker)
 
 (setq org-linker-to-heading t)


### PR DESCRIPTION
Hi,

If org-linker-edna is compiled while helm is not loaded, helm macro calls will yield "invalid function" errors, see:
https://github.com/jacktasia/dumb-jump/issues/224#issuecomment-394670211

As a solution the macro can be inlined (its small, basically just call `helm-make-source` instead), or helm required at compile time. I decided to require helm here.

Closes #10

Thanks a lot for your work!